### PR TITLE
* updates in the GrawToROOT package

### DIFF
--- a/DataFormats/CMakeLists.txt
+++ b/DataFormats/CMakeLists.txt
@@ -32,12 +32,18 @@ ROOT_GENERATE_DICTIONARY(G__${MODULE_NAME}
 #
 add_library(${MODULE_NAME} SHARED ${sources} G__${MODULE_NAME}.cxx)
 target_link_libraries(${MODULE_NAME} ${ROOT_LIBRARIES})
+
+add_executable(dummyEventTPCMaker bin/dummyEventTPCMaker.cpp)
+
 # Compiler flags.
 #
 target_compile_options(${MODULE_NAME} PUBLIC ${CMAKE_ROOT_CFLAGS})
 
+target_link_libraries(dummyEventTPCMaker PUBLIC ${MODULE_NAME})
+
 # All install commands get the same destination. this allows us to use paths
 # relative to the executable.
 install(TARGETS ${MODULE_NAME} LIBRARY DESTINATION lib)
+install(TARGETS dummyEventTPCMaker RUNTIME DESTINATION bin)
 install(FILES ${CMAKE_BINARY_DIR}/${MODULE_NAME}/lib${MODULE_NAME}_rdict.pcm DESTINATION lib)
 install(FILES ${CMAKE_BINARY_DIR}/${MODULE_NAME}/lib${MODULE_NAME}.rootmap DESTINATION lib)

--- a/DataFormats/src/SigClusterTPC.cpp
+++ b/DataFormats/src/SigClusterTPC.cpp
@@ -190,7 +190,7 @@ Reconstr_hist SigClusterTPC::Get(double radius, int rebin_space, int rebin_time,
 
 			std::map<projection, double> charge_along_direction;  // sum of charges along three directions (for a given time range)
 			for (auto dir : proj_vec_UVW) {
-				charge_along_direction[dir] = GetValByStrip(dir, uvw1[dir], icell);
+				charge_along_direction[dir] = evt_ref.GetValByStrip(dir, uvw1[dir], icell);
 			}
 
 			// loop over directions

--- a/GrawToROOT/bin/dummyEventTPCMaker.cpp
+++ b/GrawToROOT/bin/dummyEventTPCMaker.cpp
@@ -1,0 +1,73 @@
+#include <iostream>
+#include <cstdlib>
+#include <string>
+#include <memory>
+
+#include "GeometryTPC.h"
+#include "EventTPC.h"
+
+#include "TFile.h"
+#include "TTree.h"
+
+int main(int argc, char *argv[]) {
+
+  if(argc<3) return -1;
+
+  int minSignalCell = 51;
+  int maxSignalCell = 500;
+  bool skipEmptyEvents = false;
+  
+  ///Load TPC geometry
+  std::string geomFileName = "geometry_mini_eTPC.dat";
+  std::string dataFileName =  "/data/edaq/CoBo_2018-05-11T14:23:14.736_0000.graw";
+  std::string timestamp = "";
+  if(argc>3){
+    geomFileName = std::string(argv[1]);
+    std::cout<<"geomFileName: "<<geomFileName<<std::endl;
+
+    dataFileName = std::string(argv[2]);
+    std::cout<<"dataFileName: "<<dataFileName<<std::endl;
+
+    timestamp = std::string(argv[3]);
+    std::cout<<"timestamp: "<<timestamp<<std::endl;
+  }
+  GeometryTPC& myGeometry = GetGeometry(geomFileName);
+
+  ///Create event
+  std::shared_ptr<EventTPC> myEvent = std::make_shared<EventTPC>();
+
+  ///Create ROOT Tree
+  std::string rootFileName = "EventTPC_"+timestamp+".root";
+  
+  TFile aFile(rootFileName.c_str(),"RECREATE");
+  TTree aTree("TPCData","");
+
+  aTree.Branch("Event", myEvent.get());
+
+  myEvent->SetRunId(0);
+
+  for(long eventId = 0;eventId<lastevent;++eventId){
+    myEvent->Clear();
+    myEvent->SetEventId(eventId);
+    
+    int COBO_idx = 0;
+    int ASAD_idx = 0;
+    
+    for (int32_t agetId = 0; agetId < myGeometry.GetAgetNchips(); ++agetId){
+	// loop over normal channels and update channel mask for clustering
+	for (int32_t chanId = 0; chanId < myGeometry.GetAgetNchannels(); ++chanId){
+	  int iChannelGlobal     = myGeometry.Global_normal2normal(COBO_idx, ASAD_idx, agetId, chanId);// 0-255 (without FPN)
+	    for (int32_t i = 0; i < channel->fNsamples; ++i){
+     	        double aVal  = 500;
+		int32_t icell = 125;
+		myEvent->AddValByAgetChannel(COBO_idx, ASAD_idx, agetId, chanId, icell, aVal);
+	      } // end of loop over time buckets	    
+	  } // end of AGET channels loop	
+      } // end of AGET chips loop
+    aTree.Fill();
+  }
+
+  aTree.Write();
+  aFile.Close();
+  return 0;
+}

--- a/GrawToROOT/bin/grawToEventTPC.cpp
+++ b/GrawToROOT/bin/grawToEventTPC.cpp
@@ -39,13 +39,12 @@ int main(int argc, char *argv[]) {
     timestamp = std::string(argv[3]);
     std::cout<<"timestamp: "<<timestamp<<std::endl;
   }
-  GeometryTPC& myGeometryPtr = GetGeometry(geomFileName);
+  GeometryTPC& myGeometry = GetGeometry(geomFileName);
 
   ///Create event
   std::shared_ptr<EventTPC> myEvent = std::make_shared<EventTPC>();
 
   PedestalCalculator myPedestalCalculator;
-  myPedestalCalculator.SetGeometryAndInitialize(myGeometryPtr);
 
   ///Create ROOT Tree
   std::string rootFileName = "EventTPC_"+timestamp+".root";
@@ -76,12 +75,12 @@ int main(int argc, char *argv[]) {
     int COBO_idx = 0;
     int ASAD_idx = 0;
     
-    for (int32_t agetId = 0; agetId < myGeometryPtr->GetAgetNchips(); ++agetId){
+    for (int32_t agetId = 0; agetId < myGeometry.GetAgetNchips(); ++agetId){
 	// loop over normal channels and update channel mask for clustering
-	for (int32_t chanId = 0; chanId < myGeometryPtr->GetAgetNchannels(); ++chanId){
-	  int iChannelGlobal     = myGeometryPtr->Global_normal2normal(COBO_idx, ASAD_idx, agetId, chanId);// 0-255 (without FPN)
+	for (int32_t chanId = 0; chanId < myGeometry.GetAgetNchannels(); ++chanId){
+	  int iChannelGlobal     = myGeometry.Global_normal2normal(COBO_idx, ASAD_idx, agetId, chanId);// 0-255 (without FPN)
 	    
-	    GET::GDataChannel* channel = dataFrame.SearchChannel(agetId, myGeometryPtr->Aget_normal2raw(chanId));
+	    GET::GDataChannel* channel = dataFrame.SearchChannel(agetId, myGeometry.Aget_normal2raw(chanId));
 	    if (!channel) continue;
 	    
 	    for (int32_t i = 0; i < channel->fNsamples; ++i){

--- a/GrawToROOT/include/PedestalCalculator.h
+++ b/GrawToROOT/include/PedestalCalculator.h
@@ -30,8 +30,6 @@ class PedestalCalculator {
 
   ~PedestalCalculator();
 
-  void SetGeometryAndInitialize(std::shared_ptr<GeometryTPC> aPtr);
-
   double GetPedestalCorrection(int iChannelGlobal, int agentId, int iCell);
 
   void CalculateEventPedestals(const GET::GDataFrame & dataFrame);
@@ -50,7 +48,7 @@ class PedestalCalculator {
   int minSignalCell, maxSignalCell;
   int minPedestalCell, maxPedestalCell;
 
-  GeometryTPC& myGeometryPtr = GetGeometry();
+  GeometryTPC& myGeometry = GetGeometry();
 
   std::vector<double> pedestals;
 

--- a/Reconstruction/src/TrackSegment3D.cpp
+++ b/Reconstruction/src/TrackSegment3D.cpp
@@ -126,7 +126,7 @@ double TrackSegment3D::getIntegratedHitDistance(double lambdaCut) const{
   });
 #else
   return std::transform_reduce(std::execution::par_unseq, proj_vec_UVW.begin(), proj_vec_UVW.end(), myRecHits.begin(), 0.0, std::plus<>(), [&](projection strip_dir, auto& aRecHits)->auto {
-      TrackSegment2D aTrack2DProjection = get2DProjection(strip_dir, 0, lambdaCut);
+      TrackSegment2D aTrack2DProjection = this->get2DProjection(strip_dir, 0, lambdaCut);
       return aTrack2DProjection.getIntegratedHitDistance(lambdaCut, aRecHits.second);
   });
 


### PR DESCRIPTION
* fixes for compling problems with old gcc (acces to method in lambda requires an object)
* myGeometry.Global_normal2normal(COBO_idx, ASAD_idx, agetId, chanId);// 0-255 (without FPN)
not working correctly:
original version gives:

COBO_idx: 0 ASAD_idx: 0 agetId: 0 chanId 0
iChannelGlobal: 0 agetId: 0 icell: 51

current version gives:

COBO_idx: 0 ASAD_idx: 0 agetId: 0chanId 0
iChannelGlobal: 256 agetId: 0 icell: 51