### PR TITLE
Update Tests.cmake

### DIFF
--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -21,7 +21,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TEST)
     GIT_REPOSITORY
     https://github.com/google/googletest.git
     GIT_TAG
-    main
+    v1.13.0 
     ${UPDATE_DISCONNECTED_IF_AVAILABLE})
 
   set(INSTALL_GTEST OFF)


### PR DESCRIPTION
gtest 29836977ef1c664588daeb035591c18a912e7c50 requires newer cmake that we have. So instead of taking gtest master we will take the last working release