### PR TITLE
bug fix - buffer overflow error

### DIFF
--- a/DataFormats/src/GeometryTPC.cpp
+++ b/DataFormats/src/GeometryTPC.cpp
@@ -503,7 +503,7 @@ bool GeometryTPC::LoadAnalog(std::istream &f) {
   f.clear();
   f.seekg(0, std::ios::beg);
   while (getline(f, line)) {
-    char name[12], rest[1];
+    char name[13], rest[2];
     int cobo, asad, aget, chan_num;
     if (sscanf(line.c_str(), "%12s %d %d %d %d %s", name, &cobo, &asad, &aget,
                &chan_num, rest) == 5) {


### PR DESCRIPTION
```
==8==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffffb7cb5c at pc 0x7ffff6ebbd58 bp 0x7fffffb7c7f0 sp 0x7fffffb7bf78
WRITE of size 13 at 0x7fffffb7cb5c thread T0
    #0 0x7ffff6ebbd57  (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x51d57)
    #1 0x7ffff6ebca9a in vsscanf (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x52a9a)
    #2 0x7ffff6ebcbf9 in sscanf (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x52bf9)
    #3 0x7ffff5d0fa99 in GeometryTPC::LoadAnalog(std::istream&) /opt/tpcreco/tpcreco/DataFormats/src/GeometryTPC.cpp:508
    #4 0x7ffff5d0e5e4 in GeometryTPC::Load(char const*) /opt/tpcreco/tpcreco/DataFormats/src/GeometryTPC.cpp:411
    #5 0x7ffff5d0a81f in GeometryTPC::GeometryTPC(char const*, bool) /opt/tpcreco/tpcreco/DataFormats/src/GeometryTPC.cpp:69
    #6 0x572e6e in void __gnu_cxx::new_allocator<GeometryTPC>::construct<GeometryTPC, char const*, bool>(GeometryTPC*, char const*&&, bool&&) /usr/include/c++/5/ext/
new_allocator.h:120
    #7 0x570b97 in void std::allocator_traits<std::allocator<GeometryTPC> >::construct<GeometryTPC, char const*, bool>(std::allocator<GeometryTPC>&, GeometryTPC*, ch
ar const*&&, bool&&) /usr/include/c++/5/bits/alloc_traits.h:530
    #8 0x56db59 in std::_Sp_counted_ptr_inplace<GeometryTPC, std::allocator<GeometryTPC>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<char const*, bool>(std
::allocator<GeometryTPC>, char const*&&, bool&&) /usr/include/c++/5/bits/shared_ptr_base.h:522
    #9 0x56a0a0 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<GeometryTPC, std::allocator<GeometryTPC>, char const*, bool>(std::_Sp_make_shared_
tag, GeometryTPC*, std::allocator<GeometryTPC> const&, char const*&&, bool&&) /usr/include/c++/5/bits/shared_ptr_base.h:617
    #10 0x565305 in std::__shared_ptr<GeometryTPC, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<GeometryTPC>, char const*, bool>(std::_Sp_make_shared_tag
, std::allocator<GeometryTPC> const&, char const*&&, bool&&) /usr/include/c++/5/bits/shared_ptr_base.h:1097
    #11 0x560c1d in std::shared_ptr<GeometryTPC>::shared_ptr<std::allocator<GeometryTPC>, char const*, bool>(std::_Sp_make_shared_tag, std::allocator<GeometryTPC> co
nst&, char const*&&, bool&&) /usr/include/c++/5/bits/shared_ptr.h:319
    #12 0x55c54b in std::shared_ptr<GeometryTPC> std::allocate_shared<GeometryTPC, std::allocator<GeometryTPC>, char const*, bool>(std::allocator<GeometryTPC> const&
, char const*&&, bool&&) /usr/include/c++/5/bits/shared_ptr.h:620
    #13 0x558a9a in std::shared_ptr<GeometryTPC> std::make_shared<GeometryTPC, char const*, bool>(char const*&&, bool&&) /usr/include/c++/5/bits/shared_ptr.h:636
    #14 0x551f4a in main /opt/tpcreco/tpcreco/Reconstruction/bin/runTensorflow.cpp:30
    #15 0x7ffff417883f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
    #16 0x551658 in _start (/opt/tpcreco/build/bin/runTensorflow+0x551658)

Address 0x7fffffb7cb5c is located in stack of thread T0 at offset 428 in frame
    #0 0x7ffff5d0f81d in GeometryTPC::LoadAnalog(std::istream&) /opt/tpcreco/tpcreco/DataFormats/src/GeometryTPC.cpp:500

  This frame has 7 object(s):
    [32, 36) 'cobo'
    [96, 100) 'asad'
    [160, 164) 'aget'
    [224, 228) 'chan_num'
    [288, 320) 'line'
    [352, 353) 'rest'
    [416, 428) 'name' <== Memory access at offset 428 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow ??:0 ??
Shadow bytes around the buggy address:
  0x10007ff67910: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007ff67920: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007ff67930: 00 00 00 00 00 00 f1 f1 f1 f1 04 f4 f4 f4 f2 f2
  0x10007ff67940: f2 f2 04 f4 f4 f4 f2 f2 f2 f2 04 f4 f4 f4 f2 f2
  0x10007ff67950: f2 f2 04 f4 f4 f4 f2 f2 f2 f2 00 00 00 00 f2 f2
=>0x10007ff67960: f2 f2 01 f4 f4 f4 f2 f2 f2 f2 00[04]f4 f4 f3 f3
  0x10007ff67970: f3 f3 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007ff67980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007ff67990: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007ff679a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007ff679b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
```

name oraz rest, mimo wielkości tekstu kolejno 12, 1, muszą mieć dodatkowy bajt, aby przechować null char.

Zgodnie z dokumentacją https://cplusplus.com/reference/cstdio/scanf/ (takie samo zachowanie jak dla sscanf), czytająć z parametrem `s`, dodawany jest `\0` na końcu.

Do potestowania osobiście można dodać do głównego `CMakeLists.txt`:
```cmake
add_compile_options(-O0 -g3 -fsanitize=address)
set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} -g3 -fsanitize=address -lasan)
set(ROOT_EXE_LINKER_FLAGS ${ROOT_EXE_LINKER_FLAGS} -g3 -fsanitize=address -lasan)
```